### PR TITLE
Update parameters.py

### DIFF
--- a/keypy/microstates/parameters.py
+++ b/keypy/microstates/parameters.py
@@ -296,12 +296,24 @@ def compute_mstate_parameters(confobj, eeg, maps, eeg_info_study_obj):
         loading=abs(covm).max(axis=1)
         loading_all=abs(covm_all).max(axis=1)
 
-        b_loading=loading/sqrt(model.shape[1])
-        b_loading_all=loading_all/sqrt(model.shape[1])
-        		
-        exp_var=sum(b_loading)/sum(epoch[gfp_peak_indices].std(axis=1))
-        exp_var_tot=sum(b_loading_all)/sum(epoch.std(axis=1))
+#        b_loading=loading/sqrt(model.shape[1])
+#        b_loading_all=loading_all/sqrt(model.shape[1])
+# calculate square        		
+        b_loading=numpy.square(loading)/model.shape[1]
+        b_loading_all=numpy.square(loading_all)/model.shape[1]
+        
+#        exp_var=sum(b_loading)/sum(epoch[gfp_peak_indices].std(axis=1))
+#        exp_var_tot=sum(b_loading_all)/sum(epoch.std(axis=1))
+# use var instead of std
 
+        exp_var=sum(b_loading)/sum(epoch[gfp_peak_indices].var(axis=1))
+        print ('explained variance of all gfp peaks is %.6f \n' % (exp_var))
+
+        exp_var_tot=sum(b_loading_all)/sum(epoch.var(axis=1))
+        print ('explained variance of all eeg timeframes is %.6f \n' % (exp_var_tot))
+
+        
+        
         ###Compute Percentage of Correspondance between tf & labelby map
         state_match_percentage=dict.fromkeys(list(range(confobj.original_nr_of_maps)))
         state_match_percentage_std=dict.fromkeys(list(range(confobj.original_nr_of_maps)))


### PR DESCRIPTION
In my opinion, the current KeyPy code calculates the explained standard deviation, not the explained variance.
In agreement with formulas 10-12 of Pascual-Marqui's 1995 IEEE paper, the projection of the momentous map on the model map (which in KeyPy is calculated as the dot product in line 293) should be squared, and divided by the variance (not std). The same changes should be made in modelmaps.py.

Here is a simple test program with 3 channels, one model map, and one time-frame.
KeyPy gives 0.5 for the explained variance, which probably should be 0.25.

import numpy as np
from math import sqrt

nch = 3
a = sqrt (2);
model = ([-a,0,a])
b=np.sum(np.abs(model)**2,axis=-1)**(1./2)
for col in range(nch):
     model[col]=model[col]/b

org_data = ([0,-a,a])
covm_all=np.dot(org_data,model)
loading_all=covm_all
b_loading_all=(1.0*loading_all)/sqrt(nch)
eeg = org_data
exp_var_tot=(b_loading_all*b_loading_all)/np.var(eeg)

print (exp_var_tot)